### PR TITLE
Fix useZdog returns undefined values

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ function useRender(fn, deps = []) {
 }
 
 function useZdog() {
-  return useContext(stateContext)
+  const state = useContext(stateContext)
+  return state.current
 }
 
 function useZdogPrimitive(primitive, children, props, ref) {


### PR DESCRIPTION
When I tried to use `useZdog` as documented, undefined values were returned. The suggested fix modifies `useZdog` to return the `current` property of the state context. Alternatively, the value passed to `stateContext.Provider` could be changed to `state.current`, in which case `useRender` and `useZdogPrimitive` would need to be updated.