### PR TITLE
On demand rendering

### DIFF
--- a/examples/components/RenderOnDemand.js
+++ b/examples/components/RenderOnDemand.js
@@ -1,0 +1,53 @@
+import { TAU } from 'zdog'
+import React, { useEffect, useRef } from 'react'
+import { Illustration, Anchor, Shape, useInvalidate, useZdog } from 'react-zdog'
+
+const side = [[-1, -1, 1], [-1, 0, 1], [-1, 1, 1], [0, -1, 1], [0, 1, 1], [1, -1, 1], [1, 0, 1], [1, 1, 1]]
+const middle = [[1, 1, 0], [1, -1, 0], [-1, 1, 0], [-1, -1, 0]]
+
+function Dots({ stroke = 2.5, color = 'lightblue', coords, ...props }) {
+  return (
+    <Anchor {...props}>
+      {coords.map(([x, y, z], index) => (
+        <Shape key={index} stroke={stroke} color={color} translate={{ x, y, z }} />
+      ))}
+    </Anchor>
+  )
+}
+
+function Box() {
+  let ref = useRef(undefined)
+
+  return (
+    <Anchor ref={ref} scale={8}>
+      <Dots coords={side} translate={{ z: 0 }} rotate={{ y: 0 }} />
+      <Dots coords={middle} />
+      <Dots coords={side} translate={{ z: 0 }} rotate={{ x: TAU / 2 }} />
+    </Anchor>
+  )
+}
+
+const DragControl = () => {
+  const invalidate = useInvalidate()
+
+  const state = useZdog()
+
+  useEffect(() => {
+    if (state.illu) {
+      state.illu.onDragMove = function() {
+        invalidate()
+      }
+    }
+  }, [state, invalidate])
+
+  return <></>
+}
+
+export default function App() {
+  return (
+    <Illustration dragRotate={true} rotate={{ x: (TAU * -35) / 360, y: (TAU * 1) / 8 }} zoom={15} frameloop="demand">
+      <Box />
+      <DragControl />
+    </Illustration>
+  )
+}

--- a/examples/components/RenderOnDemand.js
+++ b/examples/components/RenderOnDemand.js
@@ -1,5 +1,5 @@
 import { TAU } from 'zdog'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Illustration, Anchor, Shape, useInvalidate, useZdog } from 'react-zdog'
 
 const side = [[-1, -1, 1], [-1, 0, 1], [-1, 1, 1], [0, -1, 1], [0, 1, 1], [1, -1, 1], [1, 0, 1], [1, 1, 1]]
@@ -18,9 +18,19 @@ function Dots({ stroke = 2.5, color = 'lightblue', coords, ...props }) {
 function Box() {
   let ref = useRef(undefined)
 
+  const [color, setColor] = useState('lightblue')
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      setColor(c => (c === 'lightblue' ? 'red' : 'lightblue'))
+    }, 2000)
+
+    return () => clearTimeout(t)
+  }, [])
+
   return (
     <Anchor ref={ref} scale={8}>
-      <Dots coords={side} translate={{ z: 0 }} rotate={{ y: 0 }} />
+      <Dots coords={side} translate={{ z: 0 }} rotate={{ y: 0 }} color={color} />
       <Dots coords={middle} />
       <Dots coords={side} translate={{ z: 0 }} rotate={{ x: TAU / 2 }} />
     </Anchor>

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import App from './components/Animation'
+import App from './components/Test'
 import './styles.css'
 
 //ReactDOM.unstable_createRoot(document.getElementById('root')).render(<App />)

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './components/Test'
+// import App from './components/RenderOnDemand'
 import './styles.css'
 
 //ReactDOM.unstable_createRoot(document.getElementById('root')).render(<App />)

--- a/index.js
+++ b/index.js
@@ -5,11 +5,6 @@ import ResizeObserver from 'resize-observer-polyfill'
 const stateContext = React.createContext()
 const parentContext = React.createContext()
 
-let globalEffects = []
-export function addEffect(callback) {
-  globalEffects.push(callback)
-}
-
 export function invalidate() {
   // TODO: render loop has to be able to render frames on demand
 }
@@ -97,8 +92,6 @@ const Illustration = React.memo(({ children, style, resize, element: Element = '
     function render(t) {
       const { size, subscribers } = state.current
       if (size.width && size.height) {
-        // Run global effects
-        globalEffects.forEach(fn => fn(t))
         // Run local effects
         subscribers.forEach(fn => fn(t))
         // Render scene
@@ -124,8 +117,20 @@ const Illustration = React.memo(({ children, style, resize, element: Element = '
     <div
       ref={bind.ref}
       {...rest}
-      style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden', ...style }}>
-      <Element ref={canvas} style={{ display: 'block' }} width={size.width} height={size.height} />
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        boxSizing: 'border-box',
+        ...style,
+      }}>
+      <Element
+        ref={canvas}
+        style={{ display: 'block', boxSizing: 'border-box' }}
+        width={size.width}
+        height={size.height}
+      />
       {state.current.illu && <stateContext.Provider value={state} children={result} />}
     </div>
   )

--- a/index.js
+++ b/index.js
@@ -49,7 +49,13 @@ function useZdogPrimitive(primitive, children, props, ref) {
   const [node] = useState(() => new primitive(props))
 
   useImperativeHandle(ref, () => node)
-  useLayoutEffect(() => void applyProps(node, props), [props])
+  useLayoutEffect(() => {
+    applyProps(node, props)
+    if (parent) {
+      state.current.illu.updateRenderGraph()
+    }
+  }, [props])
+
   useLayoutEffect(() => {
     if (parent) {
       parent.addChild(node)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "zdog": ">=1.1"
   },
   "devDependencies": {
-    "zdog": "^1.1.0",
     "@babel/core": "7.4.4",
     "@babel/plugin-proposal-class-properties": "7.4.4",
     "@babel/plugin-proposal-do-expressions": "7.2.0",
@@ -79,6 +78,7 @@
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3",
-    "rollup-plugin-size-snapshot": "^0.8.0"
+    "rollup-plugin-size-snapshot": "^0.8.0",
+    "zdog": "1.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,7 +4281,7 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-zdog@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/zdog/-/zdog-1.1.0.tgz#88b60a73e5c8a11fcf0c29d28c0339553ffe9566"
-  integrity sha512-PlgvESx/LKMnHbfRdGvpXn/QpoDK6jmO4HyxtydIXcMYt6qr1DMwNsiqJIiU1ibryKEnlFl/JyNrNe9Tk0+Y9w==
+zdog@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/zdog/-/zdog-1.1.3.tgz#55dd17a3582a0b74d48f8bfed7b2c2f2602646a9"
+  integrity sha512-raRj6r0gPzopFm5XWBJZr/NuV4EEnT4iE+U3dp5FV5pCb588Gmm3zLIp/j9yqqcMiHH8VNQlerLTgOqL7krh6w==


### PR DESCRIPTION
Adds feature to render frames on demand. New Prop `frameloop` with possible values of `demand` and `always`. Default value is  `always` which renders frame in animation loop. if you set the value to `demand` it will only render the frames when it detects the frame changes which is more performant. All you need to do is set  Illustration `frameloop` prop to `demand`. Major caveat here is, if you mutate properties of component it will not trigger the frame render automatically since react isn't aware of chnages, that's why it introduces new hook `useInvalidate` which returns the function when used with react-zdog tree which can be used for triggering frame manually. For example if you set `dragrotate` to `true` and also `frameloop` to `demand`, you'll notice on drag rotation of scene won't work. This can be solved by calling function returned by `useInvalidate` hook within `onDrag` callback of illustration which will trigger frames rendering only when drag event being triggered which is much more efficient that rendering scene in animation loop all the time. Check RenderOnDemand.js file within example folder.